### PR TITLE
Add box for deployments of internal test installations

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -96,9 +96,9 @@ export default [
     ],
   },
   {
-    groupTitle: 'TeamCity – Merge Branches',
+    groupTitle: 'Merges',
     priority: 50,
-    columnClass: 'col-12',
+    columnClass: 'col-md-6',
     type: 'teamcity',
     typeAdapterArgs: {
       hideSuccess: true,
@@ -223,6 +223,65 @@ export default [
       {
         label: 'int/master ➞ master',
         buildId: 'Nice2AutoMerge_IntegrationMasterToMaster',
+      },
+    ],
+  },
+  {
+    groupTitle: 'Test Deployments',
+    priority: 40,
+    columnClass: 'col-md-6',
+    type: 'teamcity',
+    typeAdapterArgs: {
+      hideSuccess: true,
+    },
+    children: [
+      {
+        label: 'master.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Master',
+      },
+      {
+        label: 'test221.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test221',
+      },
+      {
+        label: 'test220.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test220',
+      },
+      {
+        label: 'test219.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test219',
+      },
+      {
+        label: 'test218.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test218',
+      },
+      {
+        label: 'test217.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test217',
+      },
+      {
+        label: 'test216.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test216',
+      },
+      {
+        label: 'test215.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test215',
+      },
+      {
+        label: 'test214.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test214',
+      },
+      {
+        label: 'test213.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test213',
+      },
+      {
+        label: 'test212.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test212',
+      },
+      {
+        label: 'test211.tocco.ch',
+        buildId: 'ContinuousDeliveryNg_Test_Test211',
       },
     ],
   },


### PR DESCRIPTION
The installations are updated twice a day (if there are changes in
the corresponding branches) and the deployments should complete
without problems. If there is a problem, it's something we have to
fix (either it's really a bug or it's a flaky test or DB change set
or something like that that has to be fixed).